### PR TITLE
Fix for login modal not closing when trying to favourite an auction

### DIFF
--- a/src/modals/AuthModal.tsx
+++ b/src/modals/AuthModal.tsx
@@ -1,10 +1,10 @@
 import { Modal, Col } from 'react-bootstrap';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
 import Login from '../components/Login';
 import Register from '../components/Register';
 import ForgotPassword from '../components/ForgotPassword';
-import { useAuth } from '../hooks/useAuth';
 
 AuthModal.route = {
   path: "/account",
@@ -12,7 +12,14 @@ AuthModal.route = {
   index: 3,
 };
 
-export default function AuthModal({ customTitle }: { customTitle?: string; }) {
+export default function AuthModal({ customTitle,
+  show = true,
+  onHide
+}: {
+  customTitle?: string;
+  show?: boolean;
+  onHide?: () => void;
+}) {
   const { user, loading } = useAuth();
   const [showLogin, setShowLogin] = useState(true);
   const [showRegister, setShowRegister] = useState(false);
@@ -38,6 +45,8 @@ export default function AuthModal({ customTitle }: { customTitle?: string; }) {
       setShowLogin(true);
       setShowRegister(false);
       setShowForgotPassword(false);
+    } else if (onHide) {
+      onHide();
     } else {
       navigate('/');
     }
@@ -53,7 +62,7 @@ export default function AuthModal({ customTitle }: { customTitle?: string; }) {
   };
 
   return (
-    <Modal show={true} onHide={handleClose}>
+    <Modal show={show} onHide={handleClose}>
       <Modal.Header closeButton>
         <Modal.Title>{getTitle()}</Modal.Title>
       </Modal.Header>

--- a/src/parts/AuctionCard.tsx
+++ b/src/parts/AuctionCard.tsx
@@ -11,7 +11,7 @@ export default function AuctionCard(props: Auction) {
   const { id, title, currentBid, endTime } = props;
   const { user } = useAuth();
   const isFavoritedByUser = !!user?.likedAuctions?.some(a => a.id === id);
-  const { isFavorited, showAuthModal, onFavorite } = useFavorite(isFavoritedByUser, props);
+  const { isFavorited, showAuthModal, onFavorite, setShowAuthModal } = useFavorite(isFavoritedByUser, props);
   const remainingTimeMessage = getRemainingTimeMessage(endTime);
 
   return (
@@ -37,7 +37,11 @@ export default function AuctionCard(props: Auction) {
         </Card.Body>
       </Card>
       {showAuthModal && (
-        <AuthModal customTitle="Log in to favourite auctions" />
+        <AuthModal
+          customTitle="Log in to favourite auctions"
+          show={showAuthModal}
+          onHide={() => setShowAuthModal(false)}
+        />
       )}
     </>
   );


### PR DESCRIPTION
Now users will no longer be stuck on login modal when trying to favourite an auction on the first page while not logged in.

- _Added show and onhide to AuthModal that will handle if the modal should show or not_