### PR TITLE
141- Add User ID to Auth Endpoints, 

### DIFF
--- a/backend/RestRoutes/AuthEndpoints.cs
+++ b/backend/RestRoutes/AuthEndpoints.cs
@@ -57,8 +57,10 @@ public static class AuthEndpoints
             // Assign Customer role (must exist in Orchard)
             await userManager.AddToRoleAsync(user, "Customer");
 
+            var u = user as User;
             return Results.Ok(new
             {
+                id = u?.UserId,
                 username = user.UserName,
                 email = request.Email,
                 firstName = request.FirstName,
@@ -113,6 +115,7 @@ public static class AuthEndpoints
             var u = user as User;
             return Results.Ok(new
             {
+                id = u?.UserId,
                 username = user.UserName,
                 email = u?.Email,
                 phoneNumber = u?.PhoneNumber,
@@ -144,6 +147,7 @@ public static class AuthEndpoints
 
             return Results.Ok(new
             {
+                id = u?.UserId,
                 username = user.UserName,
                 email = u?.Email,
                 phoneNumber = u?.PhoneNumber,


### PR DESCRIPTION
From teacher Thomas Bugfixes.md

Issue: Authentication endpoints (GET/POST /api/auth/login and POST /api/auth/register) were not returning the user ID in their responses, making it difficult for clients to identify and reference the authenticated user.

Solution: Added id field containing the user's UserId to all three authentication endpoint responses. Since the IUser interface doesn't expose UserId directly, we cast to the concrete User type to access the property.

Affected Files:

backend/RestRoutes/AuthEndpoints.cs:61: Added id to POST /api/auth/register response
backend/RestRoutes/AuthEndpoints.cs:114: Added id to POST /api/auth/login response
backend/RestRoutes/AuthEndpoints.cs:144: Added id to GET /api/auth/login response
Technical Note: The UserId property is only available on the concrete User class, not on the IUser interface. All three endpoints cast to User using var u = user as User; and then access u?.UserId to safely retrieve the ID.

Result: All authentication endpoints now return the user's ID along with other user information (username, email, firstName, lastName, etc.), enabling clients to easily reference and store the authenticated user's identifier.